### PR TITLE
Fix stackPosition and implement additionalCommands for CUNX

### DIFF
--- a/src/MAX.cpp
+++ b/src/MAX.cpp
@@ -368,6 +368,12 @@ PVariable MAX::getPairingInfo()
 		field->structValue->emplace("const", std::make_shared<BaseLib::Variable>(93));
 		interface->structValue->emplace("responseDelay", field);
 
+		field = std::make_shared<BaseLib::Variable>(BaseLib::VariableType::tStruct);
+		field->structValue->emplace("pos", std::make_shared<BaseLib::Variable>(3));
+		field->structValue->emplace("label", std::make_shared<BaseLib::Variable>(std::string("l10n.common.additionalcommands")));
+		field->structValue->emplace("type", std::make_shared<BaseLib::Variable>(std::string("string")));
+		interface->structValue->emplace("additionalCommands", field);
+
 		interfaces->structValue->emplace("cunx", interface);
 		//}}}
 

--- a/src/PhysicalInterfaces/IMaxInterface.cpp
+++ b/src/PhysicalInterfaces/IMaxInterface.cpp
@@ -42,6 +42,13 @@ IMaxInterface::IMaxInterface(std::shared_ptr<BaseLib::Systems::PhysicalInterface
         settings->listenThreadPriority = 0;
         settings->listenThreadPolicy = SCHED_OTHER;
     }
+
+	std::vector<std::string> additionalCommands = BaseLib::HelperFunctions::splitAll(settings->additionalCommands, ',');
+	for(std::string& command : additionalCommands)
+	{
+		BaseLib::HelperFunctions::trim(command);
+		_additionalCommands += command + "\r\n";
+	}
 }
 
 IMaxInterface::~IMaxInterface()

--- a/src/PhysicalInterfaces/IMaxInterface.h
+++ b/src/PhysicalInterfaces/IMaxInterface.h
@@ -48,6 +48,7 @@ public:
 protected:
     BaseLib::SharedObjects* _bl = nullptr;
     BaseLib::Output _out;
+	std::string _additionalCommands;
 };
 
 }


### PR DESCRIPTION
The previous PR #3 was missing one `stackPrefix` when initializing Moritz mode (`Zr` was sent without prefix).

This also implements the configuration option "additionalCommands" for CUNX as a "workaround" for https://github.com/Homegear/Homegear/issues/353. I added the ZaFDXXXX command to the max.conf file as additionalCommands and do not have missing ACKs on my window contacts any longer. 

NB: It's only implemented for CUNX as I can't test it for CUL or other devices.